### PR TITLE
Remove insecure dependencies and fix container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apk add build-base ruby-dev zlib-dev
 RUN gem install bundler -v '~> 2.3.3'
 
 COPY Gemfile /Gemfile
-COPY Gemfile.lock /Gemfile.lock
 RUN bundle install
 
 RUN apk --no-cache add curl ca-certificates wget

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
     net-http-persistent (3.1.0)
       connection_pool (~> 2.2)
     netrc (0.11.0)
-    nokogiri (1.13.3-x86_64-linux)
+    nokogiri (1.13.4-x86_64-linux)
       racc (~> 1.4)
     openid_connect (1.1.8)
       activemodel
@@ -272,7 +272,7 @@ GEM
     webrick (1.7.0)
     webrobots (0.1.2)
     websocket (1.0.7)
-    yajl-ruby (1.4.1)
+    yajl-ruby (1.4.2)
 
 PLATFORMS
   x86_64-linux


### PR DESCRIPTION
Update the `nokogiri` and `yajl-ruby` dependencies and remove the line that copies the local `Gemfile.lock` to the docker container. ( Closes #83 )